### PR TITLE
Improve error messages in the REPL

### DIFF
--- a/lib/terp.ex
+++ b/lib/terp.ex
@@ -46,7 +46,7 @@ defmodule Terp do
   Loads a terp module's code and returns both the result of evaluation and
   the resulting environment.
   """
-  def evaluate_source(str, env \\ fn (z) -> {:error, {:unbound_variable, z}} end) do
+  def evaluate_source(str, env \\ fn (z) -> {:error, {:unbound, z}} end) do
     str
     |> to_ast()
     |> run_eval(env)
@@ -106,24 +106,24 @@ defmodule Terp do
       iex> "(+ 5 3)"
       ...> |> Terp.Parser.parse()
       ...> |> Enum.flat_map(&Terp.Parser.to_tree/1)
-      ...> |> Enum.map(fn tree -> Terp.eval_expr(tree, fn (z) -> {:error, {:unbound_variable, z}} end) end)
+      ...> |> Enum.map(fn tree -> Terp.eval_expr(tree, fn (z) -> {:error, {:unbound, z}} end) end)
       [8]
 
       # (* 2 4 5)
       iex> "(* 2 4 5)"
       ...> |> Terp.Parser.parse()
       ...> |> Enum.flat_map(&Terp.Parser.to_tree/1)
-      ...> |> Enum.map(fn tree -> Terp.eval_expr(tree, fn (z) -> {:error, {:unbound_variable, z}} end) end)
+      ...> |> Enum.map(fn tree -> Terp.eval_expr(tree, fn (z) -> {:error, {:unbound, z}} end) end)
       [40]
 
       # (* 2 4 (+ 4 1))
       iex> "(* 2 4 (+ 4 1))"
       ...> |> Terp.Parser.parse()
       ...> |> Enum.flat_map(&Terp.Parser.to_tree/1)
-      ...> |> Enum.map(fn tree -> Terp.eval_expr(tree, fn (z) -> {:error, {:unbound_variable, z}} end) end)
+      ...> |> Enum.map(fn tree -> Terp.eval_expr(tree, fn (z) -> {:error, {:unbound, z}} end) end)
       [40]
   """
-  def eval_expr(%RoseTree{node: node, children: children} = tree, env \\ fn (y) -> {:error, {:unbound_variable, y}} end) do
+  def eval_expr(%RoseTree{node: node, children: children} = tree, env \\ fn (y) -> {:error, {:unbound, y}} end) do
     if @debug do
       IO.inspect({"TREE", tree})
     end

--- a/lib/types/type_evaluator.ex
+++ b/lib/types/type_evaluator.ex
@@ -458,7 +458,7 @@ defmodule Terp.Types.TypeEvaluator do
         {:error, e}
     end
   end
-  def unify(t1, t2), do: {:error, {:type, "Unable to unify #{t1.str} with #{t2.str}"}}
+  def unify(t1, t2), do: {:error, {:type, {:unification, %{expected: t1, received: t2}}}}
 
   @spec bind(Types.t, Types.t) :: {:ok, substitution} | {:error, {:type, String.t}}
   def bind(a, type) do

--- a/test/types/type_evaluator_test.exs
+++ b/test/types/type_evaluator_test.exs
@@ -156,7 +156,13 @@ defmodule Terp.Types.Type.TypeEvaluatorTest do
       {:error, e} = "(cons \"asdf\" '(3 2 5 9))"
       |> Types.type_check()
       |> List.first()
-      assert e == {:type, "Unable to unify Int with String"}
+      assert e == {
+        :type, {
+          :unification,
+          %{expected: %Terp.Types.Types{constructor: :Tconst, str: "Int", t: :INTEGER},
+            received: %Terp.Types.Types{constructor: :Tconst, str: "String", t: :STRING}}
+        }
+      }
     end
 
     test "infer empty? for a list of integers" do


### PR DESCRIPTION
Better, more informative error messages in the REPL.

Includes information on the expression being evaluated, and for type errors,
what was expected and received.

<img width="1008" alt="screen shot 2017-08-27 at 21 06 25" src="https://user-images.githubusercontent.com/3296027/29755817-b59dce12-8b6b-11e7-999c-6c89a612889a.png">
