### PR TITLE
Add interop with Elixir and Erlang

### DIFF
--- a/README.org
+++ b/README.org
@@ -21,7 +21,7 @@
        + Function exports
      + [[#type-system][Type system]]
        + HM type inference
-       + Higher-kinded types
+       + [[#higher-kinded-types][Higher-kinded types]]
        + Type definition/annotation
        + [[#pattern-matching][Pattern matching]] (currently limited to type constructors)
      + [[#elixirerlang-interop][Elixir/Erlang interop]]
@@ -213,7 +213,7 @@
    /Binding and using a recursive, higher-order function:/
    [[file:media/repl_type_env.png]]
 *** Higher kinded types
-    Higher kinded types (a type parameterized by another type) can be defined using =data=:
+    Higher kinded types (types parameterized by another type) are defined using =data=:
     #+BEGIN_SRC racket
      (data (Maybe a) [Just a] [Nothing])
     #+END_SRC
@@ -279,7 +279,6 @@
      $ mix terp.run test.tp
      7
    #+END_SRC
-   * With =@debug= set to =true=, the results of the file evaluation are printed to stdout.
 ** REPL
    There's a basic repl using the mix task =mix terp.repl=.
 

--- a/README.org
+++ b/README.org
@@ -4,28 +4,32 @@
 
    Currently implemented:
      + Core language features
-      + integers
-      + strings
-      + atoms
-      + basic arithmetic (=+=, =-=, =*=, =/=)
-      + booleans (=#t=, =#f=)
-      + conditionals
-        + =if then else=
-        + =cond=
-      + Lambda functions (=lambda=)
-      + variable binding (=let=)
-      + locally scoped variable binding (=let-values=)
-      + recursive functions (=letrec=)
-     + Module System
-      + Module imports
-     + Types
+       + Integers
+       + Strings
+       + Atoms
+       + Booleans (=#t=, =#f=)
+       + [[#comments][Comments]]
+       + [[#conditionals][Conditionals]]
+         + =if then else=
+         + =cond=
+       + [[#function-definition][Function definition]] (=lambda=, =defn=)
+       + [[#recursive-functions][Recursive functions]] (=letrec=, =defrec=)
+       + [[#variable-binding][Variable binding]] (=let=)
+         + locally scoped variable binding (=let-values=)
+     + [[#module-system][Module system]]
+       + Module imports
+       + Function exports
+     + [[#type-system][Type system]]
        + HM type inference
        + Higher-kinded types
        + Type definition/annotation
-       + Pattern matching (currently limited to type constructors)
+       + [[#pattern-matching][Pattern matching]] (currently limited to type constructors)
+     + [[#elixirerlang-interop][Elixir/Erlang interop]]
+     + [[#file-evaluation][File evaluation]]
+     + [[#repl][REPL]]
      + Tooling
-       + Testing utilities
-     + Elixir/Erlang interop
+       + [[#test-utilities][Test utilities]]
+     + [[#error-messages][Error messages]]
 
    Additional examples can be found in the [[https://github.com/tpoulsen/terp/tree/master/examples][examples]] directory.
 * Usage
@@ -195,12 +199,12 @@
          (lambda (x) x))
    #+END_SRC
 ** Type system
-   Terp implements Hindley-Milner type inference. Currently, type checking is performed only on code run in the REPL; this is a work in progress and will change in the future.
+   Terp implements Hindley-Milner type inference.
 
-   Expressions in the REPL are type checked prior to evaluation. If an expression fails the type check, it won't be evaluated.
-   To see the inferred type for an expressions, prefix it with =:t= or =:type=. 
+   Expressions are type checked prior to evaluation. If an expression fails the type check, it won't be evaluated.
+   To see the inferred type for an expression in the REPL, prefix it with =:t= or =:type=. 
 
-   The REPL maintains a type environment that includes functions and variables defined with =let= or =letrec=:
+   A type environment is maintained during evaluation and REPL sessions; this environment remembers the types for functions and variables.
 
    /Binding a simple variable:/
 
@@ -208,23 +212,28 @@
    
    /Binding and using a recursive, higher-order function:/
    [[file:media/repl_type_env.png]]
+*** Higher kinded types
+    Higher kinded types (a type parameterized by another type) can be defined using =data=:
+    #+BEGIN_SRC racket
+     (data (Maybe a) [Just a] [Nothing])
+    #+END_SRC
+    This defines a type, =Maybe=, that is parameterized by another type (represented by the type variable =a=). Concrete examples could be =Maybe Int= or =Maybe String=.
+    Using =Maybe Int= as an example, values of the =Maybe Int= type can be either =Just Int= or =Nothing=. This can be used to work with values that can potentially be non-existent. 
+
+    Defining a type with =data= also defines constructor functions for the value constructors of the type (=Just= and =Nothing= in this example).
 ** Pattern matching
    #+BEGIN_SRC racket
      (data (Maybe a) [Just a] [Nothing])
 
-     (type maybePlusFive (-> [Just Int] [Just Int]))
-     (defn maybePlusFive
-       (x)
-       (match (x)
-               [(Just y) (Just (+ 5 y))]
-               [(Nothing) (Nothing)]))
+     (type maybePlusFive (-> [Maybe Int] [Maybe Int]))
+     (defn maybePlusFive (x) (match (x) [(Just y) (Just (+ 5 y))] [(Nothing) (Nothing)]))
 
      (maybePlusFive (Just 5))
      ;; Just 10
      (maybePlusFive (Nothing))
      ;; Nothing
    #+END_SRC
-** Using Elixir/Erlang functions
+** Elixir/Erlang interop
    Elixir and Erlang functions can be used by prefixing them with a =:=, e.g:
    #+BEGIN_SRC racket
      ;; Using Elixir functions directly:
@@ -245,12 +254,14 @@
      (square '(1 2 3 4 5))
      ;; '(1 4 9 16 25)
    #+END_SRC
+   *Caveats*
+
    There are currently a few important things to keep in mind:
    1) This is not yet thoroughly tested. There's a large surface area to test to make sure everything works as expected.
-   2) Type inference does not work for Elixir/Erlang functions.
-      2a) When writing functions using them, type annotations should be provided for them. See =./examples/elixir_interop.tp= for examples/details.
+   2) Type inference does not work for Elixir/Erlang functions. When writing functions that use Elixir/Erlang functions, type annotations should be provided for used functions. See =./examples/elixir_interop.tp= for examples/details.
    3) The full module and function names must be provided.
-** Evaluating a file:
+   4) Elixir and Erlang functions aren't curried.
+** File evaluation
    There's a mix task (=mix terp.run $FILENAME=) to evaluate a file:
 
    Filename =test.tp= (=terp= files must end in =.tp=):
@@ -276,10 +287,12 @@
    [[file:media/repl_demo.gif]] 
 
    As a workaround for history/scrollback in the repl, start it as =iex -S mix terp.repl=. The IEx shell provides those features while still running the terp repl.
-** Tests
+** Test utilities
    There's a mix task (=mix terp.test [$FILENAME | $DIRECTORY]=) to find and run tests in the given file(s)/directories.
 
    Test files *must* end in =_test.tp= or they will not be run.
+
+   If a directory is provided to =mix terp.test=, its subdirectories are recursively checked for files to test.
 
    =prelude/test.tp= exports the functions =test=, =assert=, and =refute=. See the documentation in [[https://github.com/tpoulsen/terp/blob/add-testing-features/prelude/test/runner.tp][prelude/test/runner.tp]] for more information.
    #+BEGIN_SRC racket
@@ -297,6 +310,6 @@
 
      [[file:media/test_run.png]]
 
-** Error Messages
+** Error messages
    To help with debugging, error messages try to be as informative as possible:
    [[file:media/error_messages.png]]

--- a/README.org
+++ b/README.org
@@ -258,7 +258,7 @@
 
    There are currently a few important things to keep in mind:
    1) This is not yet thoroughly tested. There's a large surface area to test to make sure everything works as expected.
-   2) Type inference does not work for Elixir/Erlang functions. When writing functions that use Elixir/Erlang functions, type annotations should be provided for used functions. See =./examples/elixir_interop.tp= for examples/details.
+   2) Type inference does not work for Elixir/Erlang functions. When writing functions that use Elixir/Erlang functions, type annotations should be provided for used functions. See [[./examples/elixir_interop.tp][./examples/elixir_interop.tp]] for examples/details.
    3) The full module and function names must be provided.
    4) Elixir and Erlang functions aren't curried.
 ** File evaluation
@@ -296,7 +296,7 @@
 
    =prelude/test.tp= exports the functions =test=, =assert=, and =refute=. See the documentation in [[https://github.com/tpoulsen/terp/blob/add-testing-features/prelude/test/runner.tp][prelude/test/runner.tp]] for more information.
    #+BEGIN_SRC racket
-     (type test (-> String (-> a a)))
+     (type test (-> String (-> Bool Bool)))
 
      (type assert (-> Bool Bool))
 

--- a/README.org
+++ b/README.org
@@ -25,6 +25,7 @@
        + Pattern matching (currently limited to type constructors)
      + Tooling
        + Testing utilities
+     + Elixir/Erlang interop
 
    Additional examples can be found in the [[https://github.com/tpoulsen/terp/tree/master/examples][examples]] directory.
 * Usage
@@ -223,6 +224,32 @@
      (maybePlusFive (Nothing))
      ;; Nothing
    #+END_SRC
+** Using Elixir/Erlang functions
+   Elixir and Erlang functions can be used by prefixing them with a =:=, e.g:
+   #+BEGIN_SRC racket
+     ;; Using Elixir functions directly:
+     (:Enum.map '(1 2 3 4 5) (lambda (x) (* x x)))
+     ;; '(1 4 9 16 25)
+
+     ;; Calling Elixir's uppercase function:
+     (:String.upcase "asdf")
+     ;; "ASDF"
+
+     ;; Calling Erlang's uppercase function:
+     (:string.uppercase "asdf")
+     ;; "ASDF"
+
+     ;; Writing and using a function that uses an Elixir function:
+     (defn square (xs)
+       (:Enum.map xs (lambda (x) (* x x))))
+     (square '(1 2 3 4 5))
+     ;; '(1 4 9 16 25)
+   #+END_SRC
+   There are currently a few important things to keep in mind:
+   1) This is not yet thoroughly tested. There's a large surface area to test to make sure everything works as expected.
+   2) Type inference does not work for Elixir/Erlang functions.
+      2a) When writing functions using them, type annotations should be provided for them. See =./examples/elixir_interop.tp= for examples/details.
+   3) The full module and function names must be provided.
 ** Evaluating a file:
    There's a mix task (=mix terp.run $FILENAME=) to evaluate a file:
 

--- a/examples/elixir_interop.tp
+++ b/examples/elixir_interop.tp
@@ -1,0 +1,18 @@
+;; Terp can use Elixir and Erlang functions.
+;; To use them, prefix the fully qualified name
+;; of the function (e.g. module.function) with a `:`
+(provide square
+         reverse-squares)
+
+;; Set up types for the Elixir functions that are used.
+;; Type inference cannot correctly infer their types out of the box.
+;; To actually have useful type inference, must specify types
+;; for Elixir/Erlang functions.
+(type :Enum.reverse (-> [List a] [List a]))
+(type :Stream.map (-> [List a] (-> (-> a b) [List b])))
+
+;; Squares a list and reverses it.
+(type reverse-squares (-> [List Int] [List Int]))
+(defn reverse-squares (xs)
+  (:Enum.reverse
+   (:Stream.map xs (lambda (x) (* x x)))))

--- a/examples/higher_kinded_types.tp
+++ b/examples/higher_kinded_types.tp
@@ -1,3 +1,5 @@
+(provide Maybe
+         maybePlusFive)
 ;; Defining a new type, Maybe
 (data (Maybe a) [Just a] [Nothing])
 

--- a/examples/tests/elixir_interop_test.tp
+++ b/examples/tests/elixir_interop_test.tp
@@ -1,0 +1,8 @@
+(require "examples/elixir_interop.tp")
+(require "prelude/test.tp")
+
+;; Tests Elixir interop.
+(test "reverse-squares"
+      (assert (equal?
+               (reverse-squares '(1 2 3 4 5))
+               '(25 16 9 4 1))))

--- a/examples/tests/higher_kinded_types_test.tp
+++ b/examples/tests/higher_kinded_types_test.tp
@@ -1,0 +1,12 @@
+(require "examples/higher_kinded_types.tp")
+(require "prelude/test.tp")
+
+(test "pattern matching Just"
+      (assert (equal?
+               (maybePlusFive (Just 10))
+               (Just 15))))
+
+(test "pattern matching Nothing"
+      (assert (equal?
+               (maybePlusFive (Nothing))
+               (Nothing))))

--- a/lib/terp.ex
+++ b/lib/terp.ex
@@ -95,7 +95,8 @@ defmodule Terp do
   @doc """
   Evaluate a single AST.
   """
-  def eval_tree(expr, env) do
+  def eval_tree(expr, env), do: eval_tree(expr, env, verbose: false)
+  def eval_tree(expr, env, verbose: verbose) do
     case eval_expr(expr, env) do
       x when is_function(x) ->
         {:ok, {:environment, x}}
@@ -106,7 +107,11 @@ defmodule Terp do
       %Error{} = error ->
         {:error, error, env}
       result ->
-        {:ok, {:evaluated, result, env}}
+        if verbose do
+          {:ok, {:evaluated, result, env, expr}}
+        else
+          {:ok, {:evaluated, result, env}}
+        end
     end
   end
 

--- a/lib/terp/error.ex
+++ b/lib/terp/error.ex
@@ -13,6 +13,7 @@ defmodule Terp.Error do
     Bunt.puts([:blue, "\t#{expr}"])
     Bunt.puts(["Expected: ", :blue, "#{to_string(e)}"])
     Bunt.puts(["Received: ", :red, "#{to_string(r)}"])
+    Bunt.puts([:red, "--TYPE ERROR--"])
   end
   def pretty_print_error({:error, {:type, {:annotation, %{expected: e, actual: a}}}}, expr) do
     Bunt.puts([:red, "--TYPE ERROR--"])
@@ -20,36 +21,43 @@ defmodule Terp.Error do
     Bunt.puts([:blue, "\t#{expr}"])
     Bunt.puts(["Expected type: ", :blue, "#{to_string(e)}"])
     Bunt.puts(["  Actual type: ", :red, "#{to_string(a)}"])
+    Bunt.puts([:red, "--TYPE ERROR--"])
   end
   def pretty_print_error({:error, {:type, msg}}, expr) do
     Bunt.puts([:red, "--TYPE ERROR--"])
     Bunt.puts(["#{msg} when evaluating the expression"])
     Bunt.puts([:blue, "\t#{expr}"])
+    Bunt.puts([:red, "--TYPE ERROR--"])
   end
   def pretty_print_error({:error, {:unbound, name}}, expr) do
     Bunt.puts([:red, "--UNBOUND VARIABLE ERROR--"])
     Bunt.puts([:yellow, :bright,  name, :lightgray, " is not in scope when evaluating the expression"])
     Bunt.puts([:blue, "\t#{expr}"])
+    Bunt.puts([:red, "--UNBOUND VARIABLE ERROR--"])
   end
   def pretty_print_error({:error, {:file, reason}}, file) do
     Bunt.puts([:red, "--FILE ERROR--"])
     Bunt.puts(["The following file was #{reason}:"])
     Bunt.puts([:blue, "\t#{file}"])
+    Bunt.puts([:red, "--FILE ERROR--"])
   end
   def pretty_print_error({:error, {module, reason}}, expr) do
     Bunt.puts([:red, "--#{String.upcase(to_string(module))} ERROR--"])
     Bunt.puts(["#{reason} when evaluating the expression"])
     Bunt.puts([:blue, "\t#{expr}"])
+    Bunt.puts([:red, "--#{String.upcase(to_string(module))} ERROR--"])
   end
 
   def pretty_print_error({:error, {module, reason}}) do
     Bunt.puts([:red, "--#{String.upcase(to_string(module))} ERROR--"])
     Bunt.puts(["#{reason} when evaluating the expression"])
+    Bunt.puts([:red, "--#{String.upcase(to_string(module))} ERROR--"])
   end
 
   def pretty_print_error(%Error{kind: k} = error) do
     Bunt.puts([:red, "--#{String.upcase(to_string(k))} ERROR--"])
     print_error_for_kind(error)
+    Bunt.puts([:red, "--#{String.upcase(to_string(k))} ERROR--"])
   end
 
   defp print_error_for_kind(%Error{kind: :evaluation, type: _t, message: m, evaluating: v, in_expression: expr}) do

--- a/lib/terp/test.ex
+++ b/lib/terp/test.ex
@@ -8,13 +8,13 @@ defmodule Terp.Test do
   alias Terp.Types.Types
   alias RoseTree.Zipper
 
-  def test_dir(path) do
+  def test_dir(path, state \\ %{tests: 0, failures: 0}) do
     with {:ok, files} <- File.ls(path) do
-      Enum.reduce(files, %{tests: 0, failures: 0}, fn
+      Enum.reduce(files, state, fn
         (file, %{tests: t1, failures: f1} = state) ->
         full_path = "#{path}/#{file}"
         if File.dir?(full_path) do
-          test_dir(full_path)
+          test_dir(full_path, state)
         else
           if String.ends_with?(file, "_test.tp") do
             %{tests: t2, failures: f2} = run_tests(full_path)

--- a/lib/types/annotation.ex
+++ b/lib/types/annotation.ex
@@ -1,19 +1,34 @@
 defmodule Terp.Types.Annotation do
+  alias Terp.Error
   alias Terp.Types.TypeEnvironment
   alias Terp.Types.TypeEvaluator
   alias Terp.Types.Types
 
-  def annotate_type(name, type_trees) do
+  def annotate_type(%RoseTree{node: :__beam, children: children}, type_trees) do
+    children
+    |> Enum.map(&(&1.node))
+    |> Enum.join()
+    |> RoseTree.new()
+    |> annotate_type(type_trees)
+  end
+  def annotate_type(%RoseTree{node: name}, type_trees) do
     vs = type_trees
-    |> Enum.map(fn t ->
-      if is_list(t), do: Enum.map(t, &(&1.node)), else: t.node
-    end)
+    |> Enum.map(&extract_type_nodes/1)
     t = apply(Types, :to_type, vs)
     if annotated?(name) do
       reconcile_annotation(name, t)
     else
       TypeEnvironment.annotate(name, t)
       {:ok, {%{}, t}}
+    end
+  end
+
+  # Helper to pull out the type annotations from arbitrarily nested
+  # type defs.
+  defp extract_type_nodes(%RoseTree{node: node, children: []}), do: node
+  defp extract_type_nodes(type_trees) when is_list(type_trees) do
+    for tree <- type_trees do
+      extract_type_nodes(tree)
     end
   end
 
@@ -28,6 +43,12 @@ defmodule Terp.Types.Annotation do
   end
 
   @spec reconcile_annotation(String.t | RoseTree.t, Types.t) :: {:ok, TypeEvaluator.scheme} | {:error, any()}
+  def reconcile_annotation(%{node: :__beam, children: children}, type) do
+    children
+    |> Enum.map(&(&1.node))
+    |> Enum.join()
+    |> reconcile_annotation(type)
+  end
   def reconcile_annotation(fn_name, type) when is_bitstring(fn_name) do
     with {:ok, annotated_type} <- TypeEnvironment.lookup_annotation(fn_name),
          {:ok, _sub} <- TypeEvaluator.unify(annotated_type, type) do
@@ -37,6 +58,8 @@ defmodule Terp.Types.Annotation do
       {:error, {:type, {:unification, %{expected: expected, received: actual}}}} ->
         {:error, {:type, {:annotation, %{expected: expected, actual: actual}}}}
       {:error, _e} = error ->
+        error
+      %Error{} = error ->
         error
     end
   end

--- a/lib/types/types.ex
+++ b/lib/types/types.ex
@@ -158,12 +158,17 @@ defmodule Terp.Types.Types do
   def to_type("Tuple", x, y), do: tuple(to_type(x), to_type(y))
   def to_type("Arrow", x, y), do: function(to_type(x), to_type(y))
   def to_type(:__arrow, x, y) do
+    left = if is_list(x) do
+      apply(Types, :to_type, x)
+    else
+      to_type(x)
+    end
     right = if is_list(y) do
       apply(Types, :to_type, y)
     else
       to_type(y)
     end
-    function(to_type(x), right)
+    function(left, right)
   end
 
   def replace_type_vars({type, new_vars}) do

--- a/lib/types/types.ex
+++ b/lib/types/types.ex
@@ -141,11 +141,16 @@ defmodule Terp.Types.Types do
     end
   end
 
+  # to_type/1
   def to_type(%Types{} = x), do: x
   def to_type("Int"), do: int()
   def to_type("Bool"), do: bool()
   def to_type("String"), do: string()
-  def to_type([constructor | vars]) do
+  def to_type(x), do: var(x)
+
+  # to_type/2
+  def to_type("List", x), do: list(to_type(x))
+  def to_type(constructor, vars) do
     case TypeEnvironment.lookup_def(constructor) do
       {:error, e} ->
         {:error, e}
@@ -153,8 +158,8 @@ defmodule Terp.Types.Types do
         replace_type_vars({t, vars})
     end
   end
-  def to_type(x), do: var(x)
-  def to_type("List", x), do: list(to_type(x))
+
+  # to_type/3
   def to_type("Tuple", x, y), do: tuple(to_type(x), to_type(y))
   def to_type("Arrow", x, y), do: function(to_type(x), to_type(y))
   def to_type(:__arrow, x, y) do

--- a/prelude/test/runner.tp
+++ b/prelude/test/runner.tp
@@ -11,6 +11,6 @@
 ;; Usage:
 ;;     (test "2 plus 2 is 4" (equal? #t (equal? (+ 2 2) 4)))
 ;;     -> true
-(type test (-> String (-> a a)))
+(type test (-> String (-> Bool Bool)))
 (defn test (name block)
   block)

--- a/test/types/types_test.exs
+++ b/test/types/types_test.exs
@@ -1,0 +1,5 @@
+defmodule Terp.Types.TypesTest do
+  use ExUnit.Case
+
+  
+end


### PR DESCRIPTION
Adds parsing, lexing, type checking, and evaluation for using Elixir and Erlang
functions in terp. Note that this isn't extremely thoroughly tested yet. There's
a large area to test. What has been tested (primarily in the REPL) has worked
fine. Type annotations must be provided for Elixir/Erlang functions to use them
in other function definitions.