### PR TITLE
Update module syntax to take module names instead of paths

### DIFF
--- a/README.org
+++ b/README.org
@@ -174,8 +174,8 @@
 
    Syntax is =(require ...)=, where =...= is a sequence of relative filepaths to the imported module.
    #+BEGIN_SRC racket
-     (require "examples/factorial.tp"
-              "examples/identity.tp")
+     (require examples/factorial
+              examples/identity)
 
      (factorial (identity 10))
    #+END_SRC

--- a/README.org
+++ b/README.org
@@ -1,21 +1,21 @@
 * Terp
 
-   =terp= is a toy language that falls somewhere between an ML and a lisp.
+   ~terp~ is a toy language that falls somewhere between an ML and a lisp.
 
    Currently implemented:
      + Core language features
        + Integers
        + Strings
        + Atoms
-       + Booleans (=#t=, =#f=)
+       + Booleans (~#t~, ~#f~)
        + [[#comments][Comments]]
        + [[#conditionals][Conditionals]]
-         + =if then else=
-         + =cond=
-       + [[#function-definition][Function definition]] (=lambda=, =defn=)
-       + [[#recursive-functions][Recursive functions]] (=letrec=, =defrec=)
-       + [[#variable-binding][Variable binding]] (=let=)
-         + locally scoped variable binding (=let-values=)
+         + ~if then else~
+         + ~cond~
+       + [[#function-definition][Function definition]] (~lambda~, ~defn~)
+       + [[#recursive-functions][Recursive functions]] (~letrec~, ~defrec~)
+       + [[#variable-binding][Variable binding]] (~let~)
+         + locally scoped variable binding (~let-values~)
      + [[#module-system][Module system]]
        + Module imports
        + Function exports
@@ -34,14 +34,14 @@
    Additional examples can be found in the [[https://github.com/tpoulsen/terp/tree/master/examples][examples]] directory.
 * Usage
 ** Comments
-   Comments are single-line and begin with =;;=:
+   Comments are single-line and begin with ~;;~:
    #+BEGIN_SRC racket
      ;; A comment
      (+ 5 1)
    #+END_SRC
 
 ** Variable binding
-   Variables are bound using =let=:
+   Variables are bound using ~let~:
     #+BEGIN_SRC racket
       (let x 5)
 
@@ -51,7 +51,7 @@
       ;; 5
     #+END_SRC
 
-    Local variables can be bound with =let-values=:
+    Local variables can be bound with ~let-values~:
     #+BEGIN_SRC racket
       (let-values
           ([x 5]
@@ -67,7 +67,7 @@
       ;; 6
     #+END_SRC
 ** Conditionals
-   =if= expressions must include a value for both the true and false case (an =if= and an =else=).
+   ~if~ expressions must include a value for both the true and false case (an ~if~ and an ~else~).
    #+BEGIN_SRC racket
      (if #t 5 10)
      ;; 5
@@ -77,8 +77,8 @@
      ;; 25
    #+END_SRC
 
-   =cond= can be used to test multiple possible conditions without chaining if/elses:
-   =cond= takes conditions and their outcomes should their case be true; the last condition should be a default.
+   ~cond~ can be used to test multiple possible conditions without chaining if/elses:
+   ~cond~ takes conditions and their outcomes should their case be true; the last condition should be a default.
    #+BEGIN_SRC racket
      (let sound
          (lambda (animal)
@@ -93,7 +93,7 @@
      ;; "bark"
    #+END_SRC
 ** Function definition
-   Functions are defined using =lambda=; they can be bound to a name with =let=.
+   Functions are defined using ~lambda~; they can be bound to a name with ~let~.
 
    The arguments must be wrapped in parens. The body of the function can be bare if it does not have to be evaluated (e.g. returns a single value). Otherwise, the body must be parenthesized as well.
    #+BEGIN_SRC racket
@@ -140,12 +140,12 @@
      ;; 8
    #+END_SRC
 
-   Functions can also be defined using =defn=; this is syntactic sugar for =let/lambda= definition:
+   Functions can also be defined using ~defn~; this is syntactic sugar for ~let/lambda~ definition:
    #+BEGIN_SRC racket
      (defn add (x y) (+ x y))
    #+END_SRC
 ** Recursive functions
-   Recursive functions are defined with =letrec=.
+   Recursive functions are defined with ~letrec~.
    The base case(s) and recursive case(s) must be provided or the function will not terminate.
     #+BEGIN_SRC racket
       (letrec factorial
@@ -158,7 +158,7 @@
       ;; 120
     #+END_SRC
 
-    Recursive functions can also be defined using =defrec=; this is syntactic sugar for =letrec/lambda=:
+    Recursive functions can also be defined using ~defrec~; this is syntactic sugar for ~letrec/lambda~:
     #+BEGIN_SRC racket
       (defrec factorial (n)
           (if (equal? n 0)
@@ -170,9 +170,11 @@
     #+END_SRC
 ** Module system
    Modules can be imported in to other modules to make their functions/defined expressions available.
-   Modules must specify the functions that they export or they cannot be used in other modules.
+   Modules must specify the functions that they export (via ~provide~) or they cannot be used in other modules.
 
-   Syntax is =(require ...)=, where =...= is a sequence of relative filepaths to the imported module.
+   To import a module use ~(require ...)~, where ~...~ is a sequence of module names, at the top of the file.
+   Module names are derived from their file-path relative to the project root directory (e.g. a file at ".examples/factorial.tp" has the module name ~examples/factorial~).
+
    #+BEGIN_SRC racket
      (require examples/factorial
               examples/identity)
@@ -180,10 +182,10 @@
      (factorial (identity 10))
    #+END_SRC
    
-   With [[https://github.com/tpoulsen/terp/blob/master/examples/factorial.tp]["examples/factorial.tp"]] and [[https://github.com/tpoulsen/terp/blob/master/examples/identity.tp]["examples/identity.tp"]] defined as in the examples directory.
+   With [[./examples/factorial.tp][examples/factorial]] and [[./examples/identity.tp][examples/identity]] defined as in the examples directory.
 
    To use functions from an imported module, the module that is imported must explicitly export functions it wants to make available externally.
-   The syntax is =(provide ...)= where =...= is a sequence of function names.
+   The syntax is ~(provide ...)~ where ~...~ is a sequence of function names.
    #+BEGIN_SRC racket
      ;; Module only exports factorial; identity is private.
 
@@ -202,7 +204,7 @@
    Terp implements Hindley-Milner type inference.
 
    Expressions are type checked prior to evaluation. If an expression fails the type check, it won't be evaluated.
-   To see the inferred type for an expression in the REPL, prefix it with =:t= or =:type=. 
+   To see the inferred type for an expression in the REPL, prefix it with ~:t~ or ~:type~. 
 
    A type environment is maintained during evaluation and REPL sessions; this environment remembers the types for functions and variables.
 
@@ -213,20 +215,24 @@
    /Binding and using a recursive, higher-order function:/
    [[file:media/repl_type_env.png]]
 *** Higher kinded types
-    Higher kinded types (types parameterized by another type) are defined using =data=:
+    Higher kinded types (types parameterized by another type) are defined using ~data~:
     #+BEGIN_SRC racket
      (data (Maybe a) [Just a] [Nothing])
     #+END_SRC
-    This defines a type, =Maybe=, that is parameterized by another type (represented by the type variable =a=). Concrete examples could be =Maybe Int= or =Maybe String=.
-    Using =Maybe Int= as an example, values of the =Maybe Int= type can be either =Just Int= or =Nothing=. This can be used to work with values that can potentially be non-existent. 
+    This defines a type, ~Maybe~, that is parameterized by another type (represented by the type variable ~a~). Concrete examples could be ~Maybe Int~ or ~Maybe String~.
+    Using ~Maybe Int~ as an example, values of the ~Maybe Int~ type can be either ~Just Int~ or ~Nothing~. This can be used to work with values that can potentially be non-existent. 
 
-    Defining a type with =data= also defines constructor functions for the value constructors of the type (=Just= and =Nothing= in this example).
+    Defining a type with ~data~ also defines constructor functions for the value constructors of the type (~Just~ and ~Nothing~ in this example).
 ** Pattern matching
+   ~match~ allows you to pattern match against the value constructors for a type. In this example, ~Maybe~ is a type with the value constructors ~Just~ and ~Nothing~. With ~match~, you can write a function that takes a value of type ~Maybe~ and nicely handles values that are either ~Just~ or ~Nothing~:
    #+BEGIN_SRC racket
      (data (Maybe a) [Just a] [Nothing])
 
      (type maybePlusFive (-> [Maybe Int] [Maybe Int]))
-     (defn maybePlusFive (x) (match (x) [(Just y) (Just (+ 5 y))] [(Nothing) (Nothing)]))
+     (defn maybePlusFive (x)
+       (match (x)
+         [(Just y) (Just (+ 5 y))]
+         [(Nothing) (Nothing)]))
 
      (maybePlusFive (Just 5))
      ;; Just 10
@@ -234,7 +240,7 @@
      ;; Nothing
    #+END_SRC
 ** Elixir/Erlang interop
-   Elixir and Erlang functions can be used by prefixing them with a =:=, e.g:
+   Elixir and Erlang functions can be used by prefixing them with a ~:~, e.g:
    #+BEGIN_SRC racket
      ;; Using Elixir functions directly:
      (:Enum.map '(1 2 3 4 5) (lambda (x) (* x x)))
@@ -262,9 +268,9 @@
    3) The full module and function names must be provided.
    4) Elixir and Erlang functions aren't curried.
 ** File evaluation
-   There's a mix task (=mix terp.run $FILENAME=) to evaluate a file:
+   There's a mix task (~mix terp.run $FILENAME~) to evaluate a file:
 
-   Filename =test.tp= (=terp= files must end in =.tp=):
+   Filename ~test.tp~ (~terp~ files must end in ~.tp~):
    #+BEGIN_SRC racket
      (let identity
          (lambda '(x) x))
@@ -280,20 +286,20 @@
      7
    #+END_SRC
 ** REPL
-   There's a basic repl using the mix task =mix terp.repl=.
+   There's a basic repl using the mix task ~mix terp.repl~.
 
    Currently allows expression evaluation (including module imports). History/scrollback not currently implemented.
    [[file:media/repl_demo.gif]] 
 
-   As a workaround for history/scrollback in the repl, start it as =iex -S mix terp.repl=. The IEx shell provides those features while still running the terp repl.
+   As a workaround for history/scrollback in the repl, start it as ~iex -S mix terp.repl~. The IEx shell provides those features while still running the terp repl.
 ** Test utilities
-   There's a mix task (=mix terp.test [$FILENAME | $DIRECTORY]=) to find and run tests in the given file(s)/directories.
+   There's a mix task (~mix terp.test [$FILENAME | $DIRECTORY]~) to find and run tests in the given file(s)/directories.
 
-   Test files *must* end in =_test.tp= or they will not be run.
+   Test files *must* end in ~_test.tp~ or they will not be run.
 
-   If a directory is provided to =mix terp.test=, its subdirectories are recursively checked for files to test.
+   If a directory is provided to ~mix terp.test~, its subdirectories are recursively checked for files to test.
 
-   =prelude/test.tp= exports the functions =test=, =assert=, and =refute=. See the documentation in [[https://github.com/tpoulsen/terp/blob/add-testing-features/prelude/test/runner.tp][prelude/test/runner.tp]] for more information.
+   ~prelude/test.tp~ exports the functions ~test~, ~assert~, and ~refute~. See the documentation in [[https://github.com/tpoulsen/terp/blob/add-testing-features/prelude/test/runner.tp][prelude/test/runner.tp]] for more information.
    #+BEGIN_SRC racket
      (type test (-> String (-> Bool Bool)))
 
@@ -303,7 +309,7 @@
    #+END_SRC
 
 **** Running tests
-     A symbol [✓ | x] and the name provided to =test= are printed to the console; they are color coded green/red based on pass/fail respectively.
+     A symbol [✓ | x] and the name provided to ~test~ are printed to the console; they are color coded green/red based on pass/fail respectively.
 
      The time spent running tests and a count of total tests and total failures are also printed.
 

--- a/examples/example_test.tp
+++ b/examples/example_test.tp
@@ -1,8 +1,8 @@
 ;; Examples of writing tests.
 ;; Test files must end in `_test.tp`
 
-(require "prelude/test.tp")
-(require "prelude/list.tp")
+(require prelude/test
+         prelude/list)
 
 ;; Some basic example assertions/refutations:
 (test "true is true"
@@ -18,7 +18,9 @@
 ;; uses functions/variables bound in the global scope.
 (defn plus2 (x)
   (+ 2 x))
+
 (let ls '(1 2 3 4 5))
+
 (test "mapping plus2 with external variables"
   (assert (equal?
           (map plus2 ls)

--- a/examples/function_composition.tp
+++ b/examples/function_composition.tp
@@ -1,4 +1,4 @@
-(require "prelude/function.tp")
+(require prelude/function)
 
 (let add
     (lambda (x y) (+ x y)))

--- a/examples/modules.tp
+++ b/examples/modules.tp
@@ -1,4 +1,4 @@
-(require "examples/factorial.tp"
-         "examples/identity.tp")
+(require examples/factorial
+         examples/identity)
 
 (factorial (identity 10))

--- a/examples/tests/elixir_interop_test.tp
+++ b/examples/tests/elixir_interop_test.tp
@@ -1,5 +1,5 @@
-(require "examples/elixir_interop.tp")
-(require "prelude/test.tp")
+(require examples/elixir_interop
+         prelude/test)
 
 ;; Tests Elixir interop.
 (test "reverse-squares"

--- a/examples/tests/higher_kinded_types_test.tp
+++ b/examples/tests/higher_kinded_types_test.tp
@@ -1,5 +1,5 @@
-(require "examples/higher_kinded_types.tp")
-(require "prelude/test.tp")
+(require examples/higher_kinded_types
+         prelude/test)
 
 (test "pattern matching Just"
       (assert (equal?

--- a/lib/terp.ex
+++ b/lib/terp.ex
@@ -202,7 +202,9 @@ defmodule Terp do
           :__lambda ->
             Function.lambda(operands, env)
           :__require ->
-            ModuleSystem.require_modules(Enum.map(operands, &eval_expr(&1, env)), env)
+            operands
+            |> Enum.map(&(&1.node))
+            |> ModuleSystem.require_modules(env)
           :__provide ->
             :noop
           :"__+" ->

--- a/lib/terp/module_system.ex
+++ b/lib/terp/module_system.ex
@@ -32,7 +32,7 @@ defmodule Terp.ModuleSystem do
     {{:ok, {:imported, Enum.join(stringified_imports, "\n")}}, env}
   end
   def require_modules([filename | filenames], env, imports) do
-    with {:ok, module} <- File.read(filename),
+    with {:ok, module} <- File.read(filename <> ".tp"),
          {:ok, _types} = Types.type_check(module),
          ast = module |> Parser.parse() |> Enum.flat_map(&AST.to_tree/1),
          {_res, environment} = Terp.run_eval(ast, env) do

--- a/lib/terp/parser.ex
+++ b/lib/terp/parser.ex
@@ -246,6 +246,7 @@ defmodule Terp.Parser do
       string_to_atom(ignore(char(":")) |> word()),
       both(hyphenated_word(), char("?"), &(&1 <> &2)),
       both(hyphenated_word(), char("!"), &(&1 <> &2)),
+      module_path(),
       hyphenated_word(),
       string_parser(),
       lazy(fn -> list_parser() end),
@@ -255,13 +256,11 @@ defmodule Terp.Parser do
   # BEAM terms, Elixir and Erlang expressions, should
   # be prefixed with a `:`.
   defp beam_term_parser() do
-    sequence([
-      ignore(
-        char(":")),
-      hyphenated_word(),
-      ignore(char(".")),
-      string_to_atom(hyphenated_word()),
-    ])
+    [ignore(char(":")),
+     hyphenated_word(),
+     ignore(char(".")),
+     string_to_atom(hyphenated_word())]
+    |> sequence()
     |> map(&{:__beam, &1})
   end
 
@@ -344,6 +343,12 @@ defmodule Terp.Parser do
                 _ -> true end),
       fn x -> {:__comment, x} end
     )
+  end
+
+  defp module_path() do
+    hyphenated_word()
+    |> sep_by1(char("/"))
+    |> map(&Enum.join(&1, "/"))
   end
 
   defp hyphenated_word() do

--- a/lib/types/type_evaluator.ex
+++ b/lib/types/type_evaluator.ex
@@ -1,4 +1,7 @@
 defmodule Terp.Types.TypeEvaluator do
+  @moduledoc """
+  The primary type inference module.
+  """
   alias Terp.Error
   alias Terp.Types.Types
   alias Terp.Types.Annotation
@@ -111,7 +114,8 @@ defmodule Terp.Types.TypeEvaluator do
                 end
             end
           ts ->
-            type_strings = Enum.map(ts, &(to_string(&1)))
+            type_strings = ts
+            |> Enum.map(&(to_string(&1)))
             |> Enum.join(", ")
             {:error, {:type, "Unable to unify list types: #{type_strings}"}}
         end
@@ -492,7 +496,8 @@ defmodule Terp.Types.TypeEvaluator do
 
   @spec compose(substitution, substitution) :: substitution
   def compose(sub1, sub2) do
-    Map.merge(sub2, sub1, fn _k, v1, _v2 -> v1 end)
+    sub2
+    |> Map.merge(sub1, fn _k, v1, _v2 -> v1 end)
     |> Enum.map(fn {t_var, t_scheme} -> {t_var, apply_sub(sub1, t_scheme)} end)
     |> Map.new()
   end

--- a/prelude/prelude.tp
+++ b/prelude/prelude.tp
@@ -1,8 +1,7 @@
 ;; (module prelude.prelude)
 ;; Imports and re-exports the other modules in the directory.
-(require "prelude/list.tp"
-         "prelude/function.tp"
-         )
+(require prelude/list
+         prelude/function)
 
 (provide foldl
          foldr

--- a/prelude/test.tp
+++ b/prelude/test.tp
@@ -1,7 +1,7 @@
 ;; (module prelude.test)
 ;; Provides utilities for writing tests.
-(require "prelude/test/assertions.tp")
-(require "prelude/test/runner.tp")
+(require prelude/test/assertions
+         prelude/test/runner)
 
 (provide assert
          refute


### PR DESCRIPTION
The module name in `(require ...)` no longer takes a filename. It is now the
module name (which is admittedly the filepath not in quotes and without the
extension).

Example:
  before: `(require "predlude/list.tp")`
  now:    `(require prelude/list)`