### PR TITLE
Update tool versions spec for elixir 1.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 20.0
-elixir 1.5
+elixir 1.5.0


### PR DESCRIPTION
While asdf-elixir will install a version with the version string "1.5"
the actual version output by `asdf list-all elixir` should be "1.5.0"